### PR TITLE
詳細ページに削除ボタンの移動を実装

### DIFF
--- a/app/action/action-itinerary.tsx
+++ b/app/action/action-itinerary.tsx
@@ -45,18 +45,3 @@ export const updateItinerary = async (id: number, data:FormData) => {
   redirect('/itinerary');
 }
 
-export const updateMemo = async (id: number, data: FormData) => {
-  const name = data.get('name') as string;
-  const content = data.get('content') as string;
-  await prisma.memo.update({
-    where: {
-      id,
-    },
-    data: {
-      name,
-      content,
-    },
-  });
-  revalidatePath('/memo');
-  redirect('/memo');
-};

--- a/app/action/action-memo.ts
+++ b/app/action/action-memo.ts
@@ -9,17 +9,18 @@ export const addMemo = async (data: FormData) => {
     revalidatePath('/memo');
   };
 
-export const deleteMemo = async (data: FormData) => {
-  const id = data.get('id') as string;
+export const deleteMemo = async (id: number) => {
   await prisma.memo.delete({
     where: {
-      id: Number(id),
+      id,
     },
   });
   revalidatePath('/memo');
+  redirect('/memo');
 };
 
 export const updateMemo = async (id: number, data: FormData) => {
+
   const name = data.get('name') as string;
   const content = data.get('content') as string;
   await prisma.memo.update({

--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -1,14 +1,16 @@
-import { ReactNode } from 'react';
+import { ReactNode, FormEvent } from 'react';
 
 type ButtonChildren = {
     children: ReactNode;
+    formAction?: (data: FormData) => Promise<void> | Promise<never>;
 }
 
-const Button: React.FC<ButtonChildren> = ({ children }) => {
+const Button: React.FC<ButtonChildren> = ({ children, formAction }) => {
+
     return (
         <button
             className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
-            type="submit">
+            type="submit" formAction={formAction}>
             {children}
         </button>
     );

--- a/app/components/DeleteModal.tsx
+++ b/app/components/DeleteModal.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import Button from './Button'
+
+const DeleteModal = () => {
+  return (
+    <div>
+      <div>
+        <h3>
+          <span>を削除しますか</span>
+        </h3>
+        <div>
+          <Button
+          >
+            キャンセル
+          </Button>
+          <Button
+          >
+            削除
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default DeleteModal

--- a/app/components/memo/MemoList.tsx
+++ b/app/components/memo/MemoList.tsx
@@ -18,12 +18,6 @@ const MemoList = async () => {
                                 編集
                             </Button>
                         </Link>
-                        <form action={deleteMemo}>
-                        <input type="hidden" name="id" value={memo.id} />  
-                        <Button>
-                            削除
-                        </Button>
-                        </form>      
                     </div>
                 )
             })}  

--- a/app/memo/[id]/page.tsx
+++ b/app/memo/[id]/page.tsx
@@ -1,12 +1,13 @@
 import prisma from '../../lib/prisma';
-import { updateMemo } from '../../action/action-memo';
+import { updateMemo, deleteMemo } from '../../action/action-memo';
 import Button from '@/app/components/Button';
 import Textarea from '@/app/components/Textarea';
 import Form from '@/app/components/Form';
 
 const Page = async ({ params }: { params: { id: string } }) => {
   const id = Number(params.id);
-  const updateMemoId = updateMemo.bind(null, id);
+  const updateMemoWidthId = updateMemo.bind(null, id);
+  const deleteTodoWithId = deleteMemo.bind(null, id);
   const memo = await prisma.memo.findUnique({
     where: {
       id,
@@ -15,26 +16,32 @@ const Page = async ({ params }: { params: { id: string } }) => {
 
   return (
     <main className="flex justify-center p-8">
-      <div className="flex justify-center p-8">
-        <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 w-96" action={updateMemoId} >
-          <Form 
-            name={"name"}
-            label={"メモの見出し"}
-            defaultValue={memo?.name}
-            placeholder='変更する内容を記載しましょう。'
-          />
-          <Textarea
-            name={"content"}
-            label={"メモする内容"}
-            defaultValue={memo?.content}
-            placeholder='変更する内容を記載しましょう。'
-          />
-          <Button>
-            保存
-          </Button>
+  <div className="flex justify-center p-8">
+    <div className="flex flex-col space-y-4"> 
+      <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 w-96" >
+        <Form
+          name={"name"}
+          label={"メモの見出し"}
+          defaultValue={memo?.name}
+          placeholder='変更する内容を記載しましょう。'
+        />
+        <Textarea
+          name={"content"}
+          label={"メモする内容"}
+          defaultValue={memo?.content}
+          placeholder='変更する内容を記載しましょう。'
+        />
+        <Button formAction={updateMemoWidthId}>
+          保存
+        </Button>
+        <input type="hidden" name="id" value={id} />
+        <Button formAction={deleteTodoWithId}>
+          削除
+        </Button>
       </form>
     </div>
-    </main>
+  </div>
+</main>
   );
 }
 


### PR DESCRIPTION
## 詳細ページに削除ボタンの移動を実装

「自分用メモ」
map関数で展開したのをリンクで推移したページで利用するのに苦戦。
API ROUTERでの方法なら沢山見つかるし分かりやすいが、server actionでの実装となると苦戦。
今度、分からないことがあればメモしたのを見るようにすること。