### PR TITLE
旅程表のリファクタリング

### DIFF
--- a/app/components/itinerary/FormItinerary.tsx
+++ b/app/components/itinerary/FormItinerary.tsx
@@ -1,0 +1,51 @@
+import Form from "../Form";
+import Textarea from "../Textarea";
+import Date from "../Date";
+import Time from "../Time";
+
+type Itinerary = {
+  id: number;
+  date: string;
+  time: string;
+  name: string;
+  content: string;
+  hideContent: string;
+  isShowContent: boolean;
+};
+
+type FormItineraryProps = {
+  itinerary?: Itinerary | null;
+}
+
+const FormItinerary: React.FC<FormItineraryProps> = ({itinerary}) => {
+  return (
+    <div>
+      <Date defaultValue={itinerary?.date} />
+      <Time defaultValue={itinerary?.time} />
+      <Form
+        label={"目的"}
+        placeholder={"飛行機・食事・観光など"}
+        name={"name"}
+        defaultValue={itinerary?.name}
+      />
+      <Textarea
+        label={"補足情報"}
+        placeholder={
+          "観光地なら服装の注意。料理ならおすすめの料理などメモを記載しましょう。"
+        }
+        name={"content"}
+        defaultValue={itinerary?.content}
+      />
+      <Textarea
+        label={"補足情報2"}
+        placeholder={
+          "ここに記載したのは最初は非常時でボタンをクリックで表示されます。旅程表とは関係のない観光地の情報や乗り換え方法など記載しましょう。"
+        }
+        name={"hideContent"}
+        defaultValue={itinerary?.hideContent}
+      />
+    </div>
+  );
+};
+
+export default FormItinerary;

--- a/app/components/itinerary/HideContent.tsx
+++ b/app/components/itinerary/HideContent.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react"
+import Button from "../Button";
+
+type Itinerary = {
+  hideContent: string;
+  isShowContent: boolean;
+};
+
+type HideContentProps = {
+  itinerary?: Itinerary;
+};
+
+const HideContent: React.FC<HideContentProps> = ({ itinerary }) => {
+
+  const [ isShowContent, setIsShowContent ] = useState<boolean>(false);
+
+  const toggleShowContent = () => {
+    setIsShowContent((isShowContent) => !isShowContent)
+  };
+
+  return (
+    <>
+    {itinerary && itinerary.hideContent && (
+        <>
+          {isShowContent ? (
+            <>
+              <p>{itinerary?.hideContent}</p>
+              <Button onClick={toggleShowContent}>閉じる</Button>
+            </>
+          ) : (
+            <Button onClick={toggleShowContent}>補足情報を開く</Button>
+          )}
+        </>
+      )}
+    </>
+  );
+}
+
+export default HideContent;

--- a/app/components/itinerary/ListItinerary.tsx
+++ b/app/components/itinerary/ListItinerary.tsx
@@ -1,59 +1,33 @@
-"use client";
+import prisma from "../lib/prisma";
 import Button from "../Button";
-import { deleteItinerary, showContent } from "../../action/action-itinerary";
-import { useEffect, useState } from "react";
 import Link from "next/link";
+import HideContent from "./HideContent";
 
-interface Itinerary {
-  id: number;
+type Itinerary = {
   date: string;
   time: string;
-  name: string;
-  content: string;
-  hideContent: string;
-  isShowContent: boolean;
-}
+};
 
-const ListItinerary = ({ itineraryData }: { itineraryData: Itinerary[] }) => {
-  const [sortItinerary, setSortItinerary] = useState<Itinerary[]>([]);
-  const [isShowContent, setIsShowContent] = useState(false);
+const ListItinerary = async () => {
+  const itinerary = await prisma.itinerary.findMany();
+  const sortItineraryByDateTime = (a: Itinerary, b: Itinerary) =>
+    new Date(a.date + " " + a.time).getTime() -
+    new Date(b.date + " " + b.time).getTime();
 
-  useEffect(() => {
-    const sortByDateTime = (a: Itinerary, b: Itinerary) => {
-      const dateA = new Date(`${a.date} ${a.time}`);
-      const dateB = new Date(`${b.date} ${b.time}`);
-      return dateA.getTime() - dateB.getTime();
-    };
-    const sortedData = [...itineraryData].sort(sortByDateTime);
-    setSortItinerary(sortedData);
-  }, [itineraryData]);
+  const sortedItinerary = itinerary.sort(sortItineraryByDateTime);
 
-  const toggleShowContent = () => {
-    setIsShowContent((isShowContent) => !isShowContent);
-  };
-
+  
   return (
     <div>
       <h2>旅程表</h2>
-      {sortItinerary.map((itinerary) => {
+      {sortedItinerary.map((itinerary) => {
         return (
           <div key={itinerary.id}>
             <div>{itinerary.date}</div>
             <div>{itinerary.time}</div>
             <div>{itinerary.name}</div>
             <div>{itinerary.content}</div>
-            {itinerary.hideContent && (
-              <>
-                {isShowContent ? (
-                  <>
-                    <p>{itinerary.hideContent}</p>
-                    <Button onClick={toggleShowContent}>閉じる</Button>
-                  </>
-                ) : (
-                  <Button onClick={toggleShowContent}>補足情報を開く</Button>
-                )}
-              </>
-            )}
+            <HideContent itinerary={itinerary} />
             <Link href={`/itinerary/${itinerary.id}`}>
               <Button>編集</Button>
             </Link>

--- a/app/components/memo/FormMemo.tsx
+++ b/app/components/memo/FormMemo.tsx
@@ -10,6 +10,7 @@ type Memo = {
 type FormMemoProps = {
   memo?: Memo | null;
 }
+
 const FormMemo: React.FC<FormMemoProps> = ({ memo }) => {
   return (
     <div>

--- a/app/itinerary/[id]/page.tsx
+++ b/app/itinerary/[id]/page.tsx
@@ -5,6 +5,7 @@ import Form from "@/app/components/Form";
 import Textarea from "@/app/components/Textarea";
 import Time from "@/app/components/Time";
 import Button from "@/app/components/Button";
+import FormItinerary from "@/app/components/itinerary/FormItinerary";
 
 const page = async ({ params }: { params: { id: string } }) => {
   const id = Number(params.id);
@@ -20,11 +21,7 @@ const page = async ({ params }: { params: { id: string } }) => {
     <main className="flex justify-center p-8">
       <div className="flex justify-center p-8">
         <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 w-96">
-          <Date defaultValue={itinerary?.date}/>
-          <Time defaultValue={itinerary?.time}/>
-          <Form label={"目的"} name={"name"} defaultValue={itinerary?.name} />
-          <Textarea label={"補足説明"} name={"content"} defaultValue={itinerary?.content}  />
-          <Textarea label={"補足説明"} name={"hideContent"} defaultValue={itinerary?.hideContent}  />
+          <FormItinerary itinerary={itinerary} />
           <Button formAction={updateItineraryWithId}>
             保存
           </Button>

--- a/app/itinerary/page.tsx
+++ b/app/itinerary/page.tsx
@@ -1,41 +1,22 @@
-import ListItinerary from "../components/itinerary/ListItinerary";
-import Form from "../components/Form";
-import Textarea from "../components/Textarea";
-import Date from "../components/Date";
-import Time from "../components/Time";
-import Button from "../components/Button";
 import { addItinerary } from "../action/action-itinerary";
+import FormItinerary from "../components/itinerary/FormItinerary";
+import ListItinerary from "../components/itinerary/ListItinerary";
+import Button from "../components/Button";
 
 const page = async () => {
-  // ItineraryListがクライアント側なのでこちらに記述しpropsで渡す
-  const itineraryData = await prisma.itinerary.findMany();
-
   return (
-    <main className="flex justify-center p-8">
-      <div className="flex justify-center p-8">
-        <form  className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 w-96" action={addItinerary}>
-          <Date />
-          <Time />
-          <Form 
-            label={"目的"} 
-            placeholder={"飛行機・食事・観光など"} 
-            name={"name"}  />
-          <Textarea 
-            label={"補足情報"} 
-            placeholder={"観光地なら服装の注意。料理ならおすすめの料理などメモを記載しましょう。"} 
-            name={"content"}  />
-          <Textarea 
-            label={"補足情報2"} 
-            placeholder={"ここに記載したのは最初は非常時でボタンをクリックで表示されます。旅程表とは関係のない観光地の情報や乗り換え方法など記載しましょう。"} 
-            name={"hideContent"}  />
-          <Button>
-            追加
-          </Button>
+    <main>
+      <div>
+        <form action={addItinerary}>
+          <FormItinerary />
+          <Button>追加</Button>
         </form>
       </div>
-      <ListItinerary itineraryData={itineraryData} />
+      <div>
+        <ListItinerary />
+      </div>
     </main>
-  )
-}
+  );
+};
 
 export default page;

--- a/app/memo/[id]/page.tsx
+++ b/app/memo/[id]/page.tsx
@@ -22,7 +22,6 @@ const Page = async ({ params }: { params: { id: string } }) => {
           <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 w-96">
             <FormMemo memo={memo} />
             <Button formAction={updateMemoWidthId}>保存</Button>
-            <input type="hidden" name="id" value={id} />
             <Button formAction={deleteTodoWithId}>削除</Button>
           </form>
         </div>


### PR DESCRIPTION
## コンポ―ネントの分離

ボタン切り替えで表示と非表示を切り替える補足情報をコンポーネントに分離。
⇒clientコンポーネントのため。
Form部分をコンポーネントに分離
⇒2か所で使用しているのでコード量を減らすため。

## コードの修正

ListItineraryのsortの部分の修正。
コンポーネントの分離により各コードの修正。