### PR TITLE
旅程の画像ファイルのみを削除機能を実装

### DIFF
--- a/app/(memorybook)/memorybook/components/itinerary/FormItinerary.tsx
+++ b/app/(memorybook)/memorybook/components/itinerary/FormItinerary.tsx
@@ -9,6 +9,7 @@ import toast from "react-hot-toast";
 
 import { useModal } from "@/app/hooks/useModal";
 import { deleteItineraryImage } from "../../action/actionItinerary";
+import DeleteImageModal from "@/app/components/ui/modal/DeleteImageModal";
 import FormLayout from "../layout/FormLayout";
 import Input from "@/app/components/ui/form/Input";
 import InputHidden from "@/app/components/ui/form/InputHidden";
@@ -16,13 +17,11 @@ import TextArea from "@/app/components/ui/form/TextArea";
 import Date from "@/app/components/ui/form/Date";
 import Time from "@/app/components/ui/form/Time";
 import FormImage from "@/app/components/ui/form/FormImage";
-import DeleteModal from "@/app/components/ui/modal/DeleteModal";
 
 import { itinerarySchema } from "../../schema/itinerarySchema";
 import type { Itinerary } from "@prisma/client";
 import type { ItineraryFormState } from "@/app/(memorybook)/memorybook/types/formState";
 import type { ItineraryFormType } from "../../types/formType";
-
 
 type FormItineraryProps = {
   itinerary?: Itinerary | null;
@@ -138,13 +137,13 @@ const FormItinerary: React.FC<FormItineraryProps> = ({
         register={register}
         defaultValue={itinerary?.altText}
       />
-      {itinerary?.url && itinerary?.altText && (
-        <DeleteModal
-          DeleteName="画像"
-          name={`画像ファイル (${itinerary?.altText})`}
+      {itinerary?.url && itinerary?.altText && tripId && (
+        <DeleteImageModal
+          imageUrl={itinerary.url}
+          imageAlt={itinerary.altText}
           tripId={tripId}
+          itineraryId={itinerary.id}
           formAction={deleteItineraryImage}
-          isItem={false}
         />
       )}
       <InputHidden name="tripId" value={tripId} register={register} />

--- a/app/(memorybook)/memorybook/components/itinerary/FormItinerary.tsx
+++ b/app/(memorybook)/memorybook/components/itinerary/FormItinerary.tsx
@@ -8,6 +8,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import toast from "react-hot-toast";
 
 import { useModal } from "@/app/hooks/useModal";
+import { deleteItineraryImage } from "../../action/actionItinerary";
 import FormLayout from "../layout/FormLayout";
 import Input from "@/app/components/ui/form/Input";
 import InputHidden from "@/app/components/ui/form/InputHidden";
@@ -15,11 +16,13 @@ import TextArea from "@/app/components/ui/form/TextArea";
 import Date from "@/app/components/ui/form/Date";
 import Time from "@/app/components/ui/form/Time";
 import FormImage from "@/app/components/ui/form/FormImage";
+import DeleteModal from "@/app/components/ui/modal/DeleteModal";
 
 import { itinerarySchema } from "../../schema/itinerarySchema";
 import type { Itinerary } from "@prisma/client";
 import type { ItineraryFormState } from "@/app/(memorybook)/memorybook/types/formState";
 import type { ItineraryFormType } from "../../types/formType";
+
 
 type FormItineraryProps = {
   itinerary?: Itinerary | null;
@@ -84,7 +87,7 @@ const FormItinerary: React.FC<FormItineraryProps> = ({
       router.replace(`/memorybook/${tripId}/itinerary/`);
     }
   }, [state.message, modalId, closeModal, router, tripId]);
-  
+
   return (
     <FormLayout
       formTitle="旅程表のフォーム"
@@ -135,6 +138,15 @@ const FormItinerary: React.FC<FormItineraryProps> = ({
         register={register}
         defaultValue={itinerary?.altText}
       />
+      {itinerary?.url && itinerary?.altText && (
+        <DeleteModal
+          DeleteName="画像"
+          name={`画像ファイル (${itinerary?.altText})`}
+          tripId={tripId}
+          formAction={deleteItineraryImage}
+          isItem={false}
+        />
+      )}
       <InputHidden name="tripId" value={tripId} register={register} />
       {state.message && state.message !== "edit" && state.message !== "add" && (
         <p className="text-red-500">{state.message}</p>

--- a/app/(memorybook)/memorybook/components/layout/side-menu/DashboardSideMenu.tsx
+++ b/app/(memorybook)/memorybook/components/layout/side-menu/DashboardSideMenu.tsx
@@ -21,12 +21,6 @@ const DashboardSideMenu: React.FC<DashboardSideMenuProps> = ({ trips }) => {
               ダッシュボード
             </h3>
             <ul>
-              <Link href="/memorybook">
-                <li className="flex py-2 px-2 text-white transition duration-300 hover:text-itinerary-black hover:bg-gray-300 ">
-                  <FontAwesomeIcon icon={faHouse} className="mr-2 w-5 mt-1" />
-                  TOPページ
-                </li>
-              </Link>
               <Link href="/memorybook/dashboard/">
                 <li className="flex py-2 px-2 text-white transition duration-300 hover:text-itinerary-black hover:bg-gray-300 ">
                   <FontAwesomeIcon icon={faHouse} className="mr-2 w-5 mt-1" />
@@ -37,6 +31,12 @@ const DashboardSideMenu: React.FC<DashboardSideMenuProps> = ({ trips }) => {
                 <li className="flex py-2 px-2 text-white transition duration-300 hover:text-itinerary-black hover:bg-gray-300 ">
                   <FontAwesomeIcon icon={faHouse} className="mr-2 w-5 mt-1" />
                   プロフィール
+                </li>
+              </Link>
+              <Link href="/">
+                <li className="flex py-2 px-2 text-white transition duration-300 hover:text-itinerary-black hover:bg-gray-300 ">
+                  <FontAwesomeIcon icon={faHouse} className="mr-2 w-5 mt-1" />
+                  旅の役立ちブログ「トラベルメモリー」
                 </li>
               </Link>
             </ul>

--- a/app/(memorybook)/memorybook/components/layout/side-menu/HamburgerMenu.tsx
+++ b/app/(memorybook)/memorybook/components/layout/side-menu/HamburgerMenu.tsx
@@ -52,17 +52,25 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({ trips }) => {
         >
           <p className="py-2 border-b text-white">ダッシュボード</p>
           <ul className="text-white">
-            <Link href="/memorybook">
-              <li className="py-2 px-4 transition duration-300 hover:bg-gray-300 hover:text-gray-900">TOPページ</li>
-            </Link>
             <Link href="/memorybook/dashboard/">
-              <li className="py-2 px-4 transition duration-300 hover:bg-gray-300 hover:text-gray-900" onClick={toggleMenu}>
+              <li
+                className="py-2 px-4 transition duration-300 hover:bg-gray-300 hover:text-gray-900"
+                onClick={toggleMenu}
+              >
                 ダッシュボード
               </li>
             </Link>
             <Link href="/memorybook/dashboard/profile">
-              <li className="py-2 px-4 transition duration-300 hover:bg-gray-300 hover:text-gray-900" onClick={toggleMenu}>
+              <li
+                className="py-2 px-4 transition duration-300 hover:bg-gray-300 hover:text-gray-900"
+                onClick={toggleMenu}
+              >
                 プロフィール
+              </li>
+            </Link>
+            <Link href="/">
+              <li className="py-2 px-4 transition duration-300 hover:bg-gray-300 hover:text-gray-900">
+                旅の役立ちブログ「トラベルメモリー」
               </li>
             </Link>
           </ul>
@@ -71,7 +79,10 @@ const HamburgerMenu: React.FC<HamburgerMenuProps> = ({ trips }) => {
             return (
               <ul key={trip.id} className="text-white">
                 <Link href={`/memorybook/${trip.id}/itinerary`}>
-                  <li key={trip.id} className="py-2 px-4 transition duration-300 hover:bg-gray-300 hover:text-gray-900">
+                  <li
+                    key={trip.id}
+                    className="py-2 px-4 transition duration-300 hover:bg-gray-300 hover:text-gray-900"
+                  >
                     {trip.name}
                   </li>
                 </Link>

--- a/app/components/ui/modal/DeleteImageModal.tsx
+++ b/app/components/ui/modal/DeleteImageModal.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { createPortal } from "react-dom";
+import Image from "next/image";
+import toast from "react-hot-toast";
+
+import { useModal } from "@/app/hooks/useModal";
+import Button from "@/app/components/ui/button/Button";
+import AnimatedItem from "@/app/lib/animation/AnimatedItem";
+
+type DeleteImageModalProps = {
+  imageUrl: string;
+  imageAlt: string;
+  tripId: string;
+  itineraryId: string;
+  formAction: (data: FormData) => Promise<{ message: string } | undefined>;
+};
+
+const DeleteImageModal: React.FC<DeleteImageModalProps> = ({
+  imageUrl,
+  imageAlt,
+  tripId,
+  itineraryId,
+  formAction,
+}) => {
+  const { isModalOpen, openModal, closeModal } = useModal();
+
+  const handleSubmit = () => {
+    toast.success(`画像ファイル「${imageAlt}」を削除しました！`);
+    closeModal("deleteImageModal");
+  };
+
+  return (
+    <>
+      <Button
+        onClick={() => openModal("deleteImageModal")}
+        color="white"
+        size="small"
+        type="button"
+        className="rounded my-4"
+      >
+        画像の削除
+      </Button>
+      {isModalOpen("deleteImageModal") &&
+        createPortal(
+          <AnimatedItem
+            onClick={() => closeModal("deleteImageModal")}
+            className="fixed flex z-[200] justify-center items-center w-full h-full top-0 left-0 bg-gray-500 bg-opacity-90"
+            elementType="div"
+            animation="fadeInVariants"
+          >
+            <div
+              className="relative w-full max-w-[300px] max-h-[70vh] mx-2 border rounded border-gray-500 bg-white overflow-y-auto"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex justify-center">
+                <Image
+                  src={imageUrl}
+                  alt="削除する"
+                  width={300}
+                  height={250}
+                />
+              </div>
+              <div className="my-6 text-center font-bold">
+                <p>画像ファイル「{imageAlt}」</p>
+                <p>を削除しますか？</p>
+                <p className="text-red-500">
+                  削除されるのは画像ファイルのみとなります。旅程は削除されません。
+                </p>
+              </div>
+              <div className="pb-2">
+                <form onSubmit={handleSubmit}>
+                  <input type="hidden" name="id" value={itineraryId} />
+                  <input type="hidden" name="tripId" value={tripId} />
+                  <Button
+                    formAction={formAction}
+                    color="red"
+                    size="normal"
+                    type="submit"
+                    className="rounded"
+                  >
+                    削除
+                  </Button>
+                </form>
+              </div>
+              <Button
+                onClick={() => closeModal("deleteImageModal")}
+                color="gray"
+                size="normal"
+                type="button"
+                className="rounded my-4"
+              >
+                キャンセル
+              </Button>
+            </div>
+          </AnimatedItem>,
+          document.body
+        )}
+    </>
+  );
+};
+
+export default DeleteImageModal;


### PR DESCRIPTION
## 旅程の画像ファイルのみを削除
- 画像のみ削除するdeleteItineraryImageをactionに作成
- 旅程表の編集フォームのみ画像がある場合に削除ボタンの表示
- 画像を削除するDeleteImageModal.tsxを作成

画像をアップロードしている場合に編集画面より、旅程の画像のみを削除するボタンを実装。
専用の「DeleteImageModal」を作成。
削除の確認画面をモーダルで表示後、ボタンで画像ファイルが削除される仕様になっている。

