### PR TITLE
各種ページのbuild設定を変更 / 各種ISR設定に関する修正

### DIFF
--- a/app/(Blog)/(blog-page)/[category_slug]/[post_slug]/page.tsx
+++ b/app/(Blog)/(blog-page)/[category_slug]/[post_slug]/page.tsx
@@ -1,3 +1,5 @@
+import { notFound } from "next/navigation";
+
 import {
   getCategory,
   getPost,
@@ -5,7 +7,6 @@ import {
 import { getPosts } from "@/app/(blog)/lib/service/blogServiceMany";
 import LeftColumn from "@/app/(blog)/components/content-area/LeftColumn";
 import SideMenu from "@/app/(blog)/components/side-menu/SideMenu";
-import NotFound from "@/app/not-found";
 
 export const dynamicParams = true;
 export const revalidate = 60 * 60 * 24 * 15;
@@ -26,12 +27,7 @@ const Page = async ({
   const post = await getPost("slug", params.post_slug, "categoryAndPostImage");
 
   if (!post || post.draft === false) {
-    return (
-      <div>
-        <NotFound />
-        <p>記事が存在しないか削除された可能性があります。</p>
-      </div>
-    );
+    return notFound();
   }
 
   const formattedCreatedDate = new Date(post.createdDate).toLocaleDateString();
@@ -46,13 +42,9 @@ const Page = async ({
     !category ||
     (!category.title && category.posts.every((post) => !post.draft))
   ) {
-    return (
-      <div>
-        <NotFound />
-        <p>カテゴリが存在しないか削除された可能性があります。</p>
-      </div>
-    );
+    return notFound();
   }
+
   const filteredCategoryInArticles = category.posts.filter(
     (post) => post.slug !== params.post_slug
   );

--- a/app/(Blog)/(blog-page)/[category_slug]/[post_slug]/page.tsx
+++ b/app/(Blog)/(blog-page)/[category_slug]/[post_slug]/page.tsx
@@ -7,14 +7,14 @@ import LeftColumn from "@/app/(blog)/components/content-area/LeftColumn";
 import SideMenu from "@/app/(blog)/components/side-menu/SideMenu";
 import NotFound from "@/app/not-found";
 
+export const dynamicParams = true;
+export const revalidate = 60 * 60 * 24 * 15;
+
 export async function generateStaticParams() {
   const posts = await getPosts("categoryAndPostImage");
 
   return posts.map((post) => ({
-    params: {
-      post_slug: post.slug,
-    },
-    revalidate: 60 * 60 * 24 * 15,
+    post_slug: post.slug,
   }));
 }
 

--- a/app/(Blog)/(blog-page)/[category_slug]/page.tsx
+++ b/app/(Blog)/(blog-page)/[category_slug]/page.tsx
@@ -1,6 +1,7 @@
+import { notFound } from "next/navigation";
+
 import { getCategory } from "@/app/(blog)/lib/service/blogServiceUnique";
 import { getCategories } from "@/app/(blog)/lib/service/blogServiceMany";
-import { notFound } from "next/navigation";
 import LeftColumn from "../../components/content-area/LeftColumn";
 import SideMenu from "../../components/side-menu/SideMenu";
 

--- a/app/(Blog)/(blog-page)/[category_slug]/page.tsx
+++ b/app/(Blog)/(blog-page)/[category_slug]/page.tsx
@@ -4,14 +4,14 @@ import { notFound } from "next/navigation";
 import LeftColumn from "../../components/content-area/LeftColumn";
 import SideMenu from "../../components/side-menu/SideMenu";
 
+export const dynamicParams = true;
+export const revalidate = 60 * 60 * 24 * 15;
+
 export async function generateStaticParams() {
   const categories = await getCategories("categoryAndPostImage");
 
   return categories.map((category) => ({
-    params: {
-      category_slug: category.slug,
-    },
-    revalidate: 60 * 60 * 24 * 15,
+    category_slug: category.slug,
   }));
 }
 
@@ -26,10 +26,7 @@ const page = async ({ params }: { params: { category_slug: string } }) => {
     !category ||
     (!category.title && category.posts.every((post) => !post.draft))
   ) {
-    return (
-    notFound()
-    )
-    
+    return notFound();
   }
 
   return (

--- a/app/(Blog)/(one-column-page)/privacypolicy/page.tsx
+++ b/app/(Blog)/(one-column-page)/privacypolicy/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { blogTitle } from "../../config/blogConfig";
 
+export const dynamic = "force-static";
+
 const page = () => {
   return (
     <>

--- a/app/(Blog)/(one-column-page)/sitemaps/page.tsx
+++ b/app/(Blog)/(one-column-page)/sitemaps/page.tsx
@@ -24,6 +24,10 @@ const page = async () => {
           const draftTruePosts = category.posts.filter(
             (post) => post.draft === true
           );
+
+          if (draftTruePosts.length === 0) {
+            return null;
+          }
           return (
             <div className="px-8" key={category.id}>
               <ul className="text-[#2a7bdf]">

--- a/app/(Blog)/(one-column-page)/sitemaps/page.tsx
+++ b/app/(Blog)/(one-column-page)/sitemaps/page.tsx
@@ -3,13 +3,15 @@ import Link from "next/link";
 import { getCategories } from "../../lib/service/blogServiceMany";
 import { blogTitle } from "../../config/blogConfig";
 
+export const revalidate = 60 * 60 * 24 * 15;
+
 const page = async () => {
   const categories = await getCategories("posts");
 
   return (
     <>
       <h2>サイトマップ</h2>
-      <p className="font-semibold text-[#2a7bdf]">
+      <p className="font-semibold text-[#0b0b0c]">
         <Link href="/memorybook">
           国内旅行・海外旅行の旅程表作成しおりアプリ「旅のメモリーブック」
         </Link>

--- a/app/(Blog)/action/actionCategory.ts
+++ b/app/(Blog)/action/actionCategory.ts
@@ -1,16 +1,15 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import prisma from "@/app/lib/prisma";
 import { supabase } from "@/app/util/supabase";
 import { getCategory } from "../lib/service/blogServiceUnique";
-import { revalidatePostsAndCategories } from "@/app/(blog)/lib/revalidatePostsAndCategories";
 import { checkUserRole } from "@/app/lib/checkUserRole";
 import { validateSchema } from "@/app/lib/validateSchema";
 import { fileSaveAndValidate } from "@/app/lib/image-file-save/fileSaveAndValidate";
 
+import { revalidateSiteContents } from "../lib/revalidateSiteContents";
 import { categorySchema } from "../schema/categorySchema";
 import type { CategoryFormState } from "../types/formState";
 
@@ -85,12 +84,8 @@ export const addCategory = async (state: CategoryFormState, data: FormData) => {
     await prisma.category.create({
       data: CategoryData,
     });
-    revalidatePath(`/dashboard/category`);
-    revalidatePath(`/dashboard/post/new-post`);
 
-    if (image && image.size > 0) {
-      revalidatePath(`/dashboard/image`);
-    }
+    await revalidateSiteContents();
 
     return { message: "add" };
   } catch (error) {
@@ -146,13 +141,7 @@ export const deleteCategory = async (data: FormData) => {
       },
     });
 
-    revalidatePath(`/dashboard/category`);
-    revalidatePath(`/dashboard/post/new-post`);
-    await revalidatePostsAndCategories();
-
-    if (category?.postImage?.url) {
-      revalidatePath(`/dashboard/image`);
-    }
+    await revalidateSiteContents();
   } catch (error) {
     console.error("カテゴリの削除中にエラーが発生しました:", error);
     return { message: "カテゴリの削除中にエラーが発生しました" };
@@ -253,14 +242,7 @@ export const updateCategory = async (
       data: CategoryData,
     });
 
-    revalidatePath(`/`);
-    revalidatePath(`/dashboard/category`);
-    revalidatePath(`/dashboard/post/new-post`);
-    await revalidatePostsAndCategories();
-
-    if (image && image.size > 0) {
-      revalidatePath(`/dashboard/image`);
-    }
+    await revalidateSiteContents();
 
     return { message: "edit" };
   } catch (error) {

--- a/app/(Blog)/action/actionDashboard.ts
+++ b/app/(Blog)/action/actionDashboard.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import prisma from "@/app/lib/prisma";
@@ -44,7 +43,6 @@ export const addDashboardMemo = async (
       },
     });
 
-    revalidatePath("/dashboard");
     return { message: "add" };
   } catch {
     console.error("メモを追加する際にエラーが発生しました");
@@ -69,7 +67,6 @@ export const deleteDashboardMemo = async (data: FormData) => {
       },
     });
 
-    revalidatePath("/dashboard");
   } catch (error) {
     console.error("メモの削除中にエラーが発生しました:", error);
     return { message: "メモの削除中にエラーが発生しました" };
@@ -115,7 +112,6 @@ export const updateDashboardMemo = async (
       },
     });
     
-    revalidatePath("/dashboard");
     return { message: "edit" };
   } catch {
     console.error("メモを編集する際にエラーが発生しました");

--- a/app/(Blog)/action/actionPost.ts
+++ b/app/(Blog)/action/actionPost.ts
@@ -6,7 +6,7 @@ import { redirect } from "next/navigation";
 import prisma from "@/app/lib/prisma";
 import { supabase } from "@/app/util/supabase";
 import { getPost } from "../lib/service/blogServiceUnique";
-import { revalidatePostsAndCategories } from "@/app/(blog)/lib/revalidatePostsAndCategories";
+import { revalidateSiteContents } from "@/app/(blog)/lib/revalidateSiteContents";
 import { checkUserRole } from "@/app/lib/checkUserRole";
 import { validateSchema } from "@/app/lib/validateSchema";
 import { fileSaveAndValidate } from "@/app/lib/image-file-save/fileSaveAndValidate";
@@ -87,9 +87,8 @@ export const addPost = async (state: PostFormState, data: FormData) => {
     await prisma.post.create({
       data: postData,
     });
-    revalidatePath(`/`);
-    revalidatePath(`/dashboard/post`);
-    await revalidatePostsAndCategories();
+
+    await revalidateSiteContents();
 
     return { message: "add" };
   } catch (error) {
@@ -129,14 +128,8 @@ export const deletePost = async (data: FormData) => {
       },
     });
 
-    revalidatePath(`/`);
-    revalidatePath(`/dashboard/post`);
-    revalidatePath(`/${post?.category.slug}/${post?.slug}`);
-    await revalidatePostsAndCategories();
+    await revalidateSiteContents();
 
-    if (post?.postImage?.url) {
-      revalidatePath(`/dashboard/image`);
-    }
   } catch (error) {
     console.error("記事の削除中にエラーが発生しました:", error);
     return { message: "記事の削除中にエラーが発生しました" };
@@ -255,13 +248,7 @@ export const updatePost = async (
       data: postData,
     });
 
-    revalidatePath(`/`);
-    revalidatePath(`/dashboard/post`);
-    await revalidatePostsAndCategories();
-
-    if (image && image.size > 0) {
-      revalidatePath(`/dashboard/image`);
-    }
+    await revalidateSiteContents();
 
     return { message: "edit" };
   } catch (error) {

--- a/app/(Blog)/action/actionPostImage.ts
+++ b/app/(Blog)/action/actionPostImage.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import prisma from "@/app/lib/prisma";
@@ -47,8 +46,6 @@ export const addPostImage = async (state: ImageFormState, data: FormData) => {
           altText,
         },
       });
-
-      revalidatePath(`/dashboard/image`);
 
       return { message: "add" };
     } else {
@@ -102,7 +99,6 @@ export const deletePostImage = async (data: FormData) => {
       },
     });
 
-    revalidatePath(`/dashboard/image`);
   } catch (error) {
     console.error("画像の削除中にエラーが発生しました:", error);
     return { message: "画像の削除中にエラーが発生しました" };
@@ -183,8 +179,6 @@ export const updatePostImage = async (
             altText,
           },
         });
-
-        revalidatePath(`/dashboard/image`);
 
         return { message: "edit" };
       } else {

--- a/app/(Blog)/components/content-area/LeftColumn.tsx
+++ b/app/(Blog)/components/content-area/LeftColumn.tsx
@@ -2,7 +2,6 @@ import Breadcrumbs from "./parts/Breadcrumbs";
 import ArticleTop from "./parts/ArticleTop";
 import ArticleContentArea from "./parts/ArticleContentArea";
 import RelatedArticles from "./related-articles/RelatedArticles";
-import NotFound from "../../../not-found";
 
 import type { Post } from "@prisma/client";
 import type { PostWithCategoryAndImage } from "../../types/postTypes";
@@ -77,9 +76,7 @@ const LeftColumn: React.FC<LeftColumnProps> = ({
             />
           )}
         </>
-      ) : (
-        <NotFound />
-      )}
+      ) : null }
     </div>
   );
 };

--- a/app/(Blog)/components/section/CategoryList.tsx
+++ b/app/(Blog)/components/section/CategoryList.tsx
@@ -1,9 +1,19 @@
-import { getCategories } from "@/app/(blog)/lib/service/blogServiceMany";
 import Section from "@/app/components/layout/Section";
 import TopPageListItem from "./TopPageListItem";
 
-const CategoryList = async () => {
-  const categories = await getCategories("postsAndPostImage");
+import type { Prisma } from "@prisma/client";
+
+type CategoryListProps = {
+  categories: CategoryWithPostsAndImage[];
+};
+
+type CategoryWithPostsAndImage = Prisma.CategoryGetPayload<{
+  include: {
+    posts: true;
+    postImage: true;
+  };
+}>;
+const CategoryList: React.FC<CategoryListProps> = async ({ categories }) => {
 
   return (
     <Section bgColor="bg-white" name="カテゴリ">

--- a/app/(Blog)/components/section/NewArticleList.tsx
+++ b/app/(Blog)/components/section/NewArticleList.tsx
@@ -1,10 +1,20 @@
-import { getPosts } from "@/app/(blog)/lib/service/blogServiceMany";
 import Section from "@/app/components/layout/Section";
 import TopPageListItem from "./TopPageListItem";
 
-const NewArticleList = async () => {
-  const posts = await getPosts("categoryAndPostImage", 6);
+import type { Prisma } from "@prisma/client";
 
+type NewArticleListProps = {
+  posts: PostWithCategoryAndImage[];
+}
+
+type PostWithCategoryAndImage = Prisma.PostGetPayload<{
+  include: {
+    category: true;
+    postImage: true;
+  };
+}>;
+
+const NewArticleList:React.FC<NewArticleListProps> = ({posts}) => {
   return (
     <Section bgColor="bg-sky-50" name="新着記事">
       <div className="flex w-full my-8 flex-wrap items-center justify-center">

--- a/app/(blog)/lib/revalidateSiteContents.ts
+++ b/app/(blog)/lib/revalidateSiteContents.ts
@@ -1,9 +1,12 @@
 import { revalidatePath } from "next/cache";
 
-import { getPosts } from "@/app/(blog)/lib/service/blogServiceMany";
+import { getPosts } from "./service/blogServiceMany";
 
-export async function revalidatePostsAndCategories() {
+export async function revalidateSiteContents() {
   try {
+    revalidatePath("/");
+    revalidatePath("/sitemaps");
+
     const posts = await getPosts("category");
     const filteredPosts = posts.filter((post) => post.draft);
 

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 
+import { ModalProvider } from "./context/ModalContext";
 import Header from "./(memorybook)/memorybook/components/layout/header/Header";
 import Footer from "./(memorybook)/memorybook/components/layout/footer/Footer";
 import AnimatedItem from "./lib/animation/AnimatedItem";
@@ -14,7 +15,7 @@ export const metadata: Metadata = {
 
 const NotFound = () => {
   return (
-    <>
+    <ModalProvider>
       <Header />
       <main>
         <AnimatedItem
@@ -44,7 +45,7 @@ const NotFound = () => {
         </AnimatedItem>
       </main>
       <Footer isTopAppDirectory={true} />
-    </>
+    </ModalProvider>
   );
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,8 +5,14 @@ import FlexImageAndContents from "./components/layout/FlexImageAndContents";
 import CategoryList from "./(blog)/components/section/CategoryList";
 import NewArticleList from "./(blog)/components/section/NewArticleList";
 import Footer from "./(blog)/components/layout/blog/Footer";
+import { getCategories, getPosts } from "./(blog)/lib/service/blogServiceMany";
 
-export default function Home() {  
+export const revalidate = 60 * 60 * 24 * 15;
+
+export default async function Home() {
+  const categoriesWithPostAndImage = await getCategories("postsAndPostImage");
+  const postsWithCategoryAndPostImage = await getPosts("categoryAndPostImage", 6);
+
   return (
     <>
       <Header isTopPage={true} />
@@ -37,8 +43,8 @@ export default function Home() {
               />
             </div>
           </section>
-          <NewArticleList />
-          <CategoryList />
+          <NewArticleList posts={postsWithCategoryAndPostImage} />
+          <CategoryList categories={categoriesWithPostAndImage} />
         </div>
       </main>
       <Footer />

--- a/package-lock.json
+++ b/package-lock.json
@@ -2381,9 +2381,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001690",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
-      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
+      "version": "1.0.30001727",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## 各種ページのbuild設定を変更
- カテゴリと記事ページのISRの設定を変更
- トップページとサイトマップページもISRに変更
- プライバシーポリシーページは静的生成に変更

カテゴリ・記事ページ・トップページ・サイトマップ・はISRで静的生成されるよう変更
プライバシーポリシーに関しては再検証は行わず、ビルド時の生成のみのstaticに変更。

## 修正

- notFoundコンポーネントをmodalProviderでラップしてエラー解消
- 個別記事でデータがない場合はのnotFoundの実行に変更
- サイトマップページで記事が0記事のカテゴリは非表示に変更
- revalidateSiteContentsを作成し各actionに適用
- LeftColumnの表示条件の変更
